### PR TITLE
C4 a 528 ie 11 expand collapse fix

### DIFF
--- a/src/components/help-guide.js
+++ b/src/components/help-guide.js
@@ -136,8 +136,7 @@ export class HelpGuide {
       const { target } = e;
       const parent = target.closest('article');
       if (target.className === 'acc-heading') {
-        // .control.checked is NOT SUPPORTED in IE11
-        // target.querySelector('label').control.checked = !target.querySelector('label').control.checked;
+        // .control.checked is not supported in IE11
         parent.querySelector('input').checked = !parent.querySelector('input').checked;
       }
     });

--- a/src/components/help-guide.js
+++ b/src/components/help-guide.js
@@ -98,7 +98,7 @@ export class HelpGuide {
 
     accordionItem.checked = true;
 
-    document.querySelector(`#${itemID}`).scrollIntoView({ 
+    document.querySelector(`#${itemID}`).scrollIntoView({
       behavior: 'smooth',
     });
   }
@@ -134,8 +134,11 @@ export class HelpGuide {
   _initAccordionButtons() {
     document.body.addEventListener('click', (e) => {
       const { target } = e;
+      const parent = target.closest('article');
       if (target.className === 'acc-heading') {
-        target.querySelector('label').control.checked = !target.querySelector('label').control.checked;
+        // .control.checked is NOT SUPPORTED in IE11
+        // target.querySelector('label').control.checked = !target.querySelector('label').control.checked;
+        parent.querySelector('input').checked = !parent.querySelector('input').checked;
       }
     });
   }

--- a/src/scripts/collapse-expand.js
+++ b/src/scripts/collapse-expand.js
@@ -4,9 +4,7 @@
  */
 export function modifyAccordionState(e, newState) {
   // composedPath is not SUPPORTED IN IE11
-  // const accordionSection = e
-  //   .composedPath()
-  //   .find(element => element.classList.contains('qg-accordion'));
+  // closest is working (supported using Babel polyfill)
   const qgAccordion = e.target.closest('.qg-accordion');
   const articles = qgAccordion.querySelectorAll(
     '.qg-accordion article input[type="checkbox"]',

--- a/src/scripts/collapse-expand.js
+++ b/src/scripts/collapse-expand.js
@@ -3,8 +3,7 @@
  * @param {Boolean} newState expand or collapse state
  */
 export function modifyAccordionState(e, newState) {
-  // composedPath is not SUPPORTED IN IE11
-  // closest is working (supported using Babel polyfill)
+  // composedPath is not SUPPORTED IN IE11, closest is working (supported using Babel polyfill)
   const qgAccordion = e.target.closest('.qg-accordion');
   const articles = qgAccordion.querySelectorAll(
     '.qg-accordion article input[type="checkbox"]',

--- a/src/scripts/collapse-expand.js
+++ b/src/scripts/collapse-expand.js
@@ -3,10 +3,12 @@
  * @param {Boolean} newState expand or collapse state
  */
 export function modifyAccordionState(e, newState) {
-  const accordionSection = e
-    .composedPath()
-    .find(element => element.classList.contains('qg-accordion'));
-  const articles = accordionSection.querySelectorAll(
+  // composedPath is not SUPPORTED IN IE11
+  // const accordionSection = e
+  //   .composedPath()
+  //   .find(element => element.classList.contains('qg-accordion'));
+  const qgAccordion = e.target.closest('.qg-accordion');
+  const articles = qgAccordion.querySelectorAll(
     '.qg-accordion article input[type="checkbox"]',
   );
   articles.forEach((article) => {


### PR DESCRIPTION
Updated some methods, Closest looks like working on IE11.

Example ->
https://www.qld.gov.au/dev/food-pantry/dev/asif-task-label-buster
